### PR TITLE
#165021013 Admin or staff should be able to activate/deactivate an account on the app

### DIFF
--- a/server/src/controllers/Account.controller.js
+++ b/server/src/controllers/Account.controller.js
@@ -95,6 +95,50 @@ export default class AccountController {
     });
   }
 
+  /**
+   *@method editAccount
+   *
+   * @param {object} req
+   * @param {object} res
+   *
+   * @return {object} returns status error and message properties
+   */
+  static editAccount(req, res) {
+    const { accountNumber } = req.params;
+    const { status } = req.body;
+
+    const accountToEdit = accounts
+      .find(account => account.accountNumber === parseInt(accountNumber, 10));
+
+    if (!accountToEdit) {
+      return res.status(404).json({
+        status: 404,
+        error: 'Account does not exist'
+      });
+    }
+
+    const { status: checkStatus, accountNumber: userAccountNumber } = accountToEdit;
+    if (checkStatus === status) {
+      return res.status(409).json({
+        status: 409,
+        error: `Account is already ${status}`
+      });
+    }
+
+    accountToEdit.status = status;
+
+    const data = {
+      accountNumber: userAccountNumber,
+      owner: accountToEdit.owner,
+      status: accountToEdit.status
+    };
+
+    return res.status(200).json({
+      status: 200,
+      data,
+      message: 'Account updated successfully'
+    });
+  }
 
   /**
    *@method deleteAccount

--- a/server/src/middlewares/Authorization.js
+++ b/server/src/middlewares/Authorization.js
@@ -45,7 +45,16 @@ export default class Authorization {
    */
   static authorizeRole(role) {
     return (req, res, next) => {
-      const { role: userRole } = req.decoded;
+      const { role: userRole, isAdmin } = req.decoded;
+
+      if (role === 'admin') {
+        if (userRole !== 'staff' || (userRole === 'staff' && !isAdmin)) {
+          return res.status(401).json({
+            status: 401,
+            error: 'You are not authorized to perform this action'
+          });
+        }
+      }
 
       if (role !== userRole) {
         return res.status(401).json({

--- a/server/src/middlewares/Authorization.js
+++ b/server/src/middlewares/Authorization.js
@@ -45,16 +45,7 @@ export default class Authorization {
    */
   static authorizeRole(role) {
     return (req, res, next) => {
-      const { role: userRole, isAdmin } = req.decoded;
-
-      if (role === 'admin') {
-        if (userRole !== 'staff' || (userRole === 'staff' && !isAdmin)) {
-          return res.status(401).json({
-            status: 401,
-            error: 'You are not authorized to perform this action'
-          });
-        }
-      }
+      const { role: userRole } = req.decoded;
 
       if (role !== userRole) {
         return res.status(401).json({

--- a/server/src/routes/Account.route.js
+++ b/server/src/routes/Account.route.js
@@ -4,14 +4,17 @@ import AccountController from '../controllers/Account.controller';
 import Authorization from '../middlewares/Authorization';
 import asyncErrorHandler from '../middlewares/asyncErrorHandler';
 
-const { validateCreateAccount, validateGetAccount } = AccountValidation;
+const { validateCreateAccount, validateGetAccount, validateEditAccount } = AccountValidation;
 const { checkToken, authorizeRole } = Authorization;
-const { createAccount, getAccount, deleteAccount } = AccountController;
+const {
+  createAccount, getAccount, editAccount, deleteAccount
+} = AccountController;
 
 const router = Router();
 
 router.post('/', checkToken, authorizeRole('client'), validateCreateAccount, asyncErrorHandler(createAccount));
 router.get('/:accountNumber', checkToken, validateGetAccount, asyncErrorHandler(getAccount));
 router.delete('/:accountNumber', checkToken, authorizeRole('staff'), validateGetAccount, asyncErrorHandler(deleteAccount));
+router.patch('/:accountNumber', checkToken, authorizeRole('staff'), validateEditAccount, asyncErrorHandler(editAccount));
 
 export default router;

--- a/server/src/validations/Account.validation.js
+++ b/server/src/validations/Account.validation.js
@@ -62,4 +62,42 @@ export default class AccountValidation {
 
     return next();
   }
+
+  /**
+   *@method validateEditAccount
+
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   *
+   * @return {object} returns status error and message properties
+   */
+  static validateEditAccount(req, res, next) {
+    const { accountNumber } = req.params;
+    const { status } = req.body;
+    const isNum = /^\d+$/;
+
+    if (accountNumber.length !== 10) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Account number must be 10 digits'
+      });
+    }
+
+    if (!isNum.test(accountNumber)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Account number can only contain digits'
+      });
+    }
+
+    if (status !== 'dormant' && status !== 'active') {
+      return res.status(400).json({
+        status: 400,
+        error: 'Status can only be active or dormant'
+      });
+    }
+
+    return next();
+  }
 }

--- a/server/test/helpers/fixtures.js
+++ b/server/test/helpers/fixtures.js
@@ -110,6 +110,18 @@ const dormantAccount = {
   amount: 5000
 };
 
+const editStatus = {
+  status: 'dormant'
+};
+
+const emptyStatus = {
+  status: ''
+};
+
+const invalidStatus = {
+  status: 'irkfklm'
+};
+
 
 const emptyFirstName = { ...newUser, firstName: '' };
 const emptyLastName = { ...newUser, lastName: '' };
@@ -176,5 +188,8 @@ export {
   insufficientTransaction,
   dormantAccount,
   dormantTransaction,
-  deleteAccountNumber
+  deleteAccountNumber,
+  editStatus,
+  emptyStatus,
+  invalidStatus
 };


### PR DESCRIPTION
#### What does this PR do?
 Implement activate/deactivate-account
#### Description of Task to be completed?
```PATCH/api/v1/accounts/:accountNumber```
#### How should this be manually tested?
Use postman to test endpoint above with this header:
key:Content-Type value: application/json
#### What are the relevant pivotal tracker stories?
[#165021013](https://www.pivotaltracker.com/story/show/165021013)
#### Any background context you want to add?
N/A
#### Screenshots
N/A